### PR TITLE
fixed: Hamburger menu and logo overlap in smaller screens

### DIFF
--- a/client/src/containers/Header/Navbar.jsx
+++ b/client/src/containers/Header/Navbar.jsx
@@ -16,7 +16,7 @@ const Navbar = () => {
 
   return (
     <nav
-      className={`navbar h-16 py-[20px] p-[5%] max-sm:px-0 max-sm:py-5 flex`}
+      className={`navbar h-16 py-[20px] p-[2%] max-sm:px-0 max-sm:py-5 flex`}
     >
       <div className="pl-5">
         <Link to="/">
@@ -24,12 +24,12 @@ const Navbar = () => {
             <img
               className=" w-14 h-15"
               src={logo}
-              alt=""
+              alt="logo"
             />
             <img 
               src={logoText} 
-              className="w-15 h-10 ml-2"
-              alt="" />
+              className="w-[11rem] h-[2.5rem] md:w-[18rem] md:h-[3rem] ml-2"
+              alt="logoText" />
           </div>
         </Link>
         {/* <p className="Brand-heading">PRODUCT 3D</p> */}
@@ -68,7 +68,7 @@ const Navbar = () => {
         </button>
       </div>
 
-      <div className="ml-auto mr-5 lg:hidden">
+      <div className="ml-auto mr-5 mt-[-1rem] lg:hidden">
         <button
           className={`mobile-menu-toggle ${isMobileMenuOpen ? "open" : ""}`}
           onClick={toggleMobileMenu}


### PR DESCRIPTION
This pull request addresses the issue where the hamburger menu and logo were overlapping on smaller screens. I have made the necessary changes to fix this bug and ensure proper alignment and display of the elements.

Changes made:
- Added responsive classes to adjust the layout of the hamburger menu and logo on smaller screens.